### PR TITLE
feat: add Loki log aggregation with Alloy collector

### DIFF
--- a/clusters/production/kustomization.yaml
+++ b/clusters/production/kustomization.yaml
@@ -18,11 +18,13 @@ resources:
   - ../../components/third-party/kube-prometheus-stack
   - ../../components/third-party/kubed
   - ../../components/third-party/kured
+  - ../../components/third-party/loki
   - ../../components/third-party/metallb
   - ../../components/third-party/metrics-server
   - ../../components/third-party/minecraft
   - ../../components/third-party/mosquitto
   - ../../components/third-party/mysql
+  - ../../components/third-party/alloy
   - ../../components/third-party/redis
   - ../../components/third-party/spark-kubernetes-operator
   - ../../components/third-party/telegraf
@@ -53,11 +55,13 @@ patches:
   - path: ./overlay/third-party/kube-prometheus-stack/helmRelease.yaml
   - path: ./overlay/third-party/kubed/helmRelease.yaml
   - path: ./overlay/third-party/kured/helmRelease.yaml
+  - path: ./overlay/third-party/loki/helmRelease.yaml
   - path: ./overlay/third-party/metallb/helmRelease.yaml
   - path: ./overlay/third-party/metrics-server/helmRelease.yaml
   - path: ./overlay/third-party/minecraft-hs/helmRelease.yaml
   - path: ./overlay/third-party/mosquitto/helmRelease.yaml
   - path: ./overlay/third-party/mysql/helmRelease.yaml
+  - path: ./overlay/third-party/alloy/helmRelease.yaml
   - path: ./overlay/third-party/redis/helmRelease.yaml
   - path: ./overlay/third-party/spark-kubernetes-operator/helmRelease.yaml
   - path: ../../components/third-party/redis/ociRepo.yaml

--- a/clusters/production/overlay/third-party/alloy/helmRelease.yaml
+++ b/clusters/production/overlay/third-party/alloy/helmRelease.yaml
@@ -1,0 +1,9 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: alloy
+  namespace: monitor
+spec:
+  chart:
+    spec:
+      version: ${ALLOY_VERSION}

--- a/clusters/production/overlay/third-party/grafana/helmRelease.yaml
+++ b/clusters/production/overlay/third-party/grafana/helmRelease.yaml
@@ -15,3 +15,9 @@ spec:
     plugins:
       - volkovlabs-image-panel
       - yesoreyeram-infinity-datasource
+    additionalDataSources:
+      - name: Loki
+        type: loki
+        url: http://loki.monitor.svc.cluster.local:3100
+        access: proxy
+        isDefault: false

--- a/clusters/production/overlay/third-party/loki/helmRelease.yaml
+++ b/clusters/production/overlay/third-party/loki/helmRelease.yaml
@@ -1,0 +1,9 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: loki
+  namespace: monitor
+spec:
+  chart:
+    spec:
+      version: ${LOKI_VERSION}

--- a/clusters/production/postBuild.yaml
+++ b/clusters/production/postBuild.yaml
@@ -30,7 +30,9 @@ spec:
       MOSQUITTO_VERSION: 16.0.1 # https://artifacthub.io/packages/helm/truecharts/mosquitto
       MYSQL_VERSION: 14.0.3 # https://artifacthub.io/packages/helm/bitnami/mysql
       NGINX_VERSION: 4.15.1 # https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx
+      LOKI_VERSION: 13.5.0 # https://artifacthub.io/packages/helm/grafana-community/loki
       PROMETHEUS_VERSION: 84.5.0 # https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack
+      ALLOY_VERSION: 1.8.0 # https://artifacthub.io/packages/helm/grafana/alloy
       REDIS_VERSION: 25.4.1 # https://artifacthub.io/packages/helm/bitnami/redis
       SPARK_KUBERNETES_OPERATOR_VERSION: 1.6.0 # https://artifacthub.io/packages/helm/spark-kubernetes-operator/spark-kubernetes-operator
       TELEGRAF_VERSION: 1.8.70 # https://artifacthub.io/packages/helm/influxdata/telegraf

--- a/components/third-party/alloy/helmRelease.yaml
+++ b/components/third-party/alloy/helmRelease.yaml
@@ -1,0 +1,67 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: alloy
+  namespace: monitor
+spec:
+  releaseName: alloy
+  chart:
+    spec:
+      chart: alloy
+      version: xx # Set by flux patch
+      sourceRef:
+        kind: HelmRepository
+        name: grafana
+        namespace: flux-system
+  interval: 5m
+  install:
+    remediation:
+      retries: 3
+  dependsOn:
+    - name: loki
+      namespace: monitor
+  values:
+    alloy:
+      configMap:
+        content: |
+          discovery.kubernetes "pods" {
+            role = "pod"
+          }
+
+          discovery.relabel "pod_logs" {
+            targets = discovery.kubernetes.pods.targets
+
+            rule {
+              source_labels = ["__meta_kubernetes_namespace"]
+              target_label  = "namespace"
+            }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_name"]
+              target_label  = "pod"
+            }
+            rule {
+              source_labels = ["__meta_kubernetes_container_name"]
+              target_label  = "container"
+            }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_node_name"]
+              target_label  = "node"
+            }
+          }
+
+          loki.source.kubernetes "pod_logs" {
+            targets    = discovery.relabel.pod_logs.output
+            forward_to = [loki.write.default.receiver]
+          }
+
+          loki.write "default" {
+            endpoint {
+              url = "http://loki.monitor.svc.cluster.local:3100/loki/api/v1/push"
+            }
+          }
+    controller:
+      type: daemonset
+    resources:
+      requests:
+        cpu: "50m"
+        memory: "128Mi"

--- a/components/third-party/alloy/kustomization.yaml
+++ b/components/third-party/alloy/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- helmRelease.yaml

--- a/components/third-party/loki/helmRelease.yaml
+++ b/components/third-party/loki/helmRelease.yaml
@@ -1,0 +1,57 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: loki
+  namespace: monitor
+spec:
+  releaseName: loki
+  chart:
+    spec:
+      chart: loki
+      version: xx # Set by flux patch
+      sourceRef:
+        kind: HelmRepository
+        name: grafana-community
+        namespace: flux-system
+  interval: 5m
+  install:
+    remediation:
+      retries: 3
+  values:
+    deploymentMode: SingleBinary
+    loki:
+      auth_enabled: false
+      commonConfig:
+        replication_factor: 1
+      storage:
+        type: filesystem
+      schemaConfig:
+        configs:
+          - from: "2024-01-01"
+            store: tsdb
+            object_store: filesystem
+            schema: v13
+            index:
+              prefix: loki_index_
+              period: 24h
+    singleBinary:
+      replicas: 1
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "256Mi"
+      persistence:
+        storageClass: nfs
+        size: 20Gi
+    gateway:
+      enabled: false
+    backend:
+      replicas: 0
+    read:
+      replicas: 0
+    write:
+      replicas: 0
+    chunksCache:
+      enabled: false
+    resultsCache:
+      enabled: false

--- a/components/third-party/loki/helmRepo.yaml
+++ b/components/third-party/loki/helmRepo.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: grafana-community
+  namespace: flux-system
+spec:
+  interval: 10m
+  url: https://grafana-community.github.io/helm-charts

--- a/components/third-party/loki/kustomization.yaml
+++ b/components/third-party/loki/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- helmRepo.yaml
+- helmRelease.yaml


### PR DESCRIPTION
## Summary

- Add Loki (grafana-community OSS chart, SingleBinary, NFS PVC 20Gi) as local replacement for Azure Log Analytics Workspace
- Add Grafana Alloy v1.8.0 (DaemonSet) as log collector — replaces deprecated Promtail chart
- Add grafana-community HelmRepository for OSS Loki chart (migrated from grafana/helm-charts as of Mar 16 2026)
- Wire Loki as datasource in Grafana overlay