### PR TITLE
fix: migrate MySQL to OCI chart source for Bitnami 14.x

### DIFF
--- a/clusters/production/kustomization.yaml
+++ b/clusters/production/kustomization.yaml
@@ -64,4 +64,5 @@ patches:
   - path: ./overlay/third-party/alloy/helmRelease.yaml
   - path: ./overlay/third-party/redis/helmRelease.yaml
   - path: ./overlay/third-party/spark-kubernetes-operator/helmRelease.yaml
+  - path: ../../components/third-party/mysql/ociRepo.yaml
   - path: ../../components/third-party/redis/ociRepo.yaml

--- a/clusters/production/overlay/third-party/mysql/helmRelease.yaml
+++ b/clusters/production/overlay/third-party/mysql/helmRelease.yaml
@@ -4,9 +4,6 @@ metadata:
   name: mysql
   namespace: mysql
 spec:
-  chart:
-    spec:
-      version: ${MYSQL_VERSION} # Set in postBuild production
   values:
     image:
       debug: true

--- a/components/third-party/mysql/helmRelease.yaml
+++ b/components/third-party/mysql/helmRelease.yaml
@@ -5,14 +5,10 @@ metadata:
   namespace: mysql
 spec:
   releaseName: mysql
-  chart:
-    spec:
-      chart: mysql
-      version: xx # Set by flux patch
-      sourceRef:
-        kind: HelmRepository
-        name: mysql
-        namespace: flux-system
+  chartRef:
+    kind: OCIRepository
+    name: mysql
+    namespace: flux-system
   interval: 5m
   install:
     remediation:

--- a/components/third-party/mysql/kustomization.yaml
+++ b/components/third-party/mysql/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
 - helmRepo.yaml
 - helmRelease.yaml
 - namespace.yaml
+- ociRepo.yaml

--- a/components/third-party/mysql/ociRepo.yaml
+++ b/components/third-party/mysql/ociRepo.yaml
@@ -1,0 +1,10 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: mysql
+  namespace: flux-system
+spec:
+  interval: 10m
+  url: oci://registry-1.docker.io/bitnamicharts/mysql
+  ref:
+    semver: ${MYSQL_VERSION} # Set in postBuild production


### PR DESCRIPTION
## Summary

- Bitnami MySQL 14.x moved to OCI registry (oci://registry-1.docker.io/bitnamicharts/mysql)
- HelmRelease switches from chart.spec/HelmRepository to chartRef/OCIRepository
- Follows existing Redis OCI pattern
- Fixes PVC pending issue caused by unsupported OCI protocol on old HelmRepository