### PR TITLE
fix: correct container meta label name in Alloy pod_logs relabeling

### DIFF
--- a/components/third-party/alloy/helmRelease.yaml
+++ b/components/third-party/alloy/helmRelease.yaml
@@ -40,7 +40,7 @@ spec:
               target_label  = "pod"
             }
             rule {
-              source_labels = ["__meta_kubernetes_container_name"]
+              source_labels = ["__meta_kubernetes_pod_container_name"]
               target_label  = "container"
             }
             rule {


### PR DESCRIPTION
## Summary
- Fix wrong Kubernetes meta label `__meta_kubernetes_container_name` -> `__meta_kubernetes_pod_container_name`
- Enables `container` label to appear in Loki log streams

## Test plan
- [ ] Merge and wait for Alloy to reconcile
- [ ] Verify `container` label appears in Grafana Explore -> Loki label browser
- [ ] Verify container dropdown works in Loki dashboard