### PR TITLE
fix: restore grafana HelmRepo to official URL, point Grafana chart to grafana-community

### DIFF
--- a/clusters/production/postBuild.yaml
+++ b/clusters/production/postBuild.yaml
@@ -18,7 +18,7 @@ spec:
       GARGE_API_VERSION: 0.1.27 # https://artifacthub.io/packages/helm/garge/garge-api
       GARGE_APP_VERSION: 0.1.22 # https://artifacthub.io/packages/helm/garge/garge-app
       GARGE_OPERATOR_VERSION: 0.1.21 # https://artifacthub.io/packages/helm/garge/garge-operator
-      GRAFANA_VERSION: 10.5.15 # https://artifacthub.io/packages/helm/grafana/grafana
+      GRAFANA_VERSION: 10.5.15 # https://artifacthub.io/packages/helm/grafana-community/grafana
       HOME_ASSISTANT_VERSION_ET: 2.3.4 # https://artifacthub.io/packages/helm/alekc/home-assistant
       HOME_ASSISTANT_VERSION: 2.3.4 # https://artifacthub.io/packages/helm/alekc/home-assistant
       INFLUXDB_VERSION: 7.1.20 # https://artifacthub.io/packages/helm/bitnami/influxdb

--- a/clusters/production/postBuild.yaml
+++ b/clusters/production/postBuild.yaml
@@ -18,7 +18,7 @@ spec:
       GARGE_API_VERSION: 0.1.27 # https://artifacthub.io/packages/helm/garge/garge-api
       GARGE_APP_VERSION: 0.1.22 # https://artifacthub.io/packages/helm/garge/garge-app
       GARGE_OPERATOR_VERSION: 0.1.21 # https://artifacthub.io/packages/helm/garge/garge-operator
-      GRAFANA_VERSION: 10.5.15 # https://artifacthub.io/packages/helm/grafana-community/grafana
+      GRAFANA_VERSION: 12.3.0 # https://artifacthub.io/packages/helm/grafana-community/grafana
       HOME_ASSISTANT_VERSION_ET: 2.3.4 # https://artifacthub.io/packages/helm/alekc/home-assistant
       HOME_ASSISTANT_VERSION: 2.3.4 # https://artifacthub.io/packages/helm/alekc/home-assistant
       INFLUXDB_VERSION: 7.1.20 # https://artifacthub.io/packages/helm/bitnami/influxdb

--- a/components/third-party/grafana/helmRelease.yaml
+++ b/components/third-party/grafana/helmRelease.yaml
@@ -11,7 +11,7 @@ spec:
       version: xx # Set by flux patch
       sourceRef:
         kind: HelmRepository
-        name: grafana
+        name: grafana-community
         namespace: flux-system
   interval: 5m
   install:

--- a/components/third-party/grafana/helmRepo.yaml
+++ b/components/third-party/grafana/helmRepo.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: flux-system
 spec:
   interval: 10m
-  url: https://grafana-community.github.io/helm-charts
+  url: https://grafana.github.io/helm-charts


### PR DESCRIPTION
## Summary
- Revert `grafana` HelmRepository back to `https://grafana.github.io/helm-charts` (Alloy and other charts live here)
- Update Grafana HelmRelease to use `grafana-community` repo instead
- Fixes Alloy HelmChart error: "no chart name found"

## Test plan
- [ ] Verify Alloy HelmRelease reconciles successfully
- [ ] Verify Grafana HelmRelease reconciles successfully