### PR TITLE
feat: set Loki log retention to 90 days

### DIFF
--- a/components/third-party/loki/helmRelease.yaml
+++ b/components/third-party/loki/helmRelease.yaml
@@ -25,6 +25,10 @@ spec:
         replication_factor: 1
       storage:
         type: filesystem
+      compactor:
+        retention_enabled: true
+      limits_config:
+        retention_period: 2160h
       schemaConfig:
         configs:
           - from: "2024-01-01"


### PR DESCRIPTION
## Summary
- Enable compactor retention in Loki
- Set retention period to 2160h (90 days)
- Logs older than 90 days will be automatically deleted

## Test plan
- [ ] Verify Loki reconciles successfully after merge