### PR TITLE
fix: add delete_request_store to Loki compactor config

### DIFF
--- a/components/third-party/loki/helmRelease.yaml
+++ b/components/third-party/loki/helmRelease.yaml
@@ -27,6 +27,7 @@ spec:
         type: filesystem
       compactor:
         retention_enabled: true
+        delete_request_store: filesystem
       limits_config:
         retention_period: 2160h
       schemaConfig:


### PR DESCRIPTION
## Summary
- Loki failed to start with retention enabled — `compactor.delete-request-store` was missing
- Add `delete_request_store: filesystem` to match existing filesystem storage backend

## Test plan
- [ ] Flux reconciles HelmRelease
- [ ] `loki-0` pod starts without config error
- [ ] Retention/compaction works as expected