### PR TITLE
fix(nstuning-app): preserve path on apex to www redirect

### DIFF
--- a/clusters/production/overlay/third-party/nstuning-app/ingress.yaml
+++ b/clusters/production/overlay/third-party/nstuning-app/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     meta.helm.sh/release-name: nstuning-app
     meta.helm.sh/release-namespace: nstuning-prod
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
-    nginx.ingress.kubernetes.io/permanent-redirect: "https://www.nstuning.no"
+    nginx.ingress.kubernetes.io/permanent-redirect: "https://www.nstuning.no$request_uri"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
 spec:
   ingressClassName: nginx


### PR DESCRIPTION
The apex redirect ingress (`nstuning-redirect`) used `permanent-redirect: https://www.nstuning.no`, which sends every apex request to the www **root** and drops the path. So `nstuning.no/foobar` landed on the www homepage (200) instead of `www.nstuning.no/foobar` (404) — letting junk paths get indexed.

Append `$request_uri` so the path + query are preserved (nginx evaluates the variable in the redirect target).

After Flux applies: `nstuning.no/foobar` → 308 → `www.nstuning.no/foobar` → 404. Valid apex paths still canonicalize to www.

Note: garge-app has the same missing `$request_uri` in its apex redirect (`overlay/third-party/garge-app/ingress.yaml`) — separate fix if wanted.
