### PR TITLE
fix(nstuning-api): raise memory limit to 512Mi

### DIFF
--- a/clusters/production/overlay/third-party/nstuning-api/helmRelease.yaml
+++ b/clusters/production/overlay/third-party/nstuning-api/helmRelease.yaml
@@ -53,10 +53,10 @@ spec:
             - nstuning-api-dev.prod.tumogroup.com
     resources:
       requests:
-        memory: "256Mi"
+        memory: "512Mi"
         cpu: "500m"
       limits:
-        memory: "256Mi"
+        memory: "512Mi"
         cpu: "500m"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
@@ -113,8 +113,8 @@ spec:
             - nstuning-api.prod.tumogroup.com
     resources:
       requests:
-        memory: "256Mi"
+        memory: "512Mi"
         cpu: "500m"
       limits:
-        memory: "256Mi"
+        memory: "512Mi"
         cpu: "500m"

--- a/components/third-party/nstuning-api/helmRelease.yaml
+++ b/components/third-party/nstuning-api/helmRelease.yaml
@@ -20,10 +20,10 @@ spec:
   values:
     resources:
       requests:
-        memory: "256Mi"
+        memory: "512Mi"
         cpu: "500m"
       limits:
-        memory: "256Mi"
+        memory: "512Mi"
         cpu: "500m"
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
@@ -48,8 +48,8 @@ spec:
   values:
     resources:
       requests:
-        memory: "256Mi"
+        memory: "512Mi"
         cpu: "500m"
       limits:
-        memory: "256Mi"
+        memory: "512Mi"
         cpu: "500m"


### PR DESCRIPTION
## Summary
Raise nstuning-api memory from 256Mi to 512Mi (dev + prod, requests=limits).

256Mi was too tight for the .NET + SkiaSharp webp image pipeline; decoding an uploaded photo pushed the pod over the limit and it was OOMKilled (exit 137, crashloop). 512Mi gives headroom for image processing.

Changes both the base component and the production overlay.
