### PR TITLE
feat: set logformat serilog podLabel on .NET app pods

### DIFF
--- a/clusters/production/overlay/third-party/bobby-api/helmRelease.yaml
+++ b/clusters/production/overlay/third-party/bobby-api/helmRelease.yaml
@@ -18,6 +18,8 @@ spec:
         secretKeyRef:
           key: API_PASSWORD
           name: bobby-api-secrets
+    podLabels:
+      logformat: serilog
     image:
       pullPolicy: Always
     ingress:

--- a/clusters/production/overlay/third-party/garge-api/helmRelease.yaml
+++ b/clusters/production/overlay/third-party/garge-api/helmRelease.yaml
@@ -74,6 +74,8 @@ spec:
         secretKeyRef:
           key: APP__APIBASEURL
           name: garge-api-secrets
+    podLabels:
+      logformat: serilog
     image:
       tag: "dev"
       pullPolicy: Always
@@ -174,6 +176,8 @@ spec:
         secretKeyRef:
           key: APP__APIBASEURL
           name: garge-api-secrets
+    podLabels:
+      logformat: serilog
     image:
       pullPolicy: Always
     ingress:

--- a/clusters/production/overlay/third-party/garge-operator/helmRelease.yaml
+++ b/clusters/production/overlay/third-party/garge-operator/helmRelease.yaml
@@ -46,6 +46,8 @@ spec:
         secretKeyRef:
           key: WEBHOOK__SECRET
           name: garge-operator-secrets
+    podLabels:
+      logformat: serilog
     image:
       tag: "dev"
       pullPolicy: Always
@@ -105,6 +107,8 @@ spec:
         secretKeyRef:
           key: WEBHOOK__SECRET
           name: garge-operator-secrets
+    podLabels:
+      logformat: serilog
     image:
       pullPolicy: Always
     resources:

--- a/clusters/production/overlay/third-party/nstuning-api/helmRelease.yaml
+++ b/clusters/production/overlay/third-party/nstuning-api/helmRelease.yaml
@@ -34,6 +34,8 @@ spec:
         secretKeyRef:
           key: BREVOSETTINGS__SENDERNAME
           name: nstuning-api-secrets
+    podLabels:
+      logformat: serilog
     image:
       tag: "dev"
       pullPolicy: Always
@@ -95,6 +97,8 @@ spec:
         secretKeyRef:
           key: BREVOSETTINGS__SENDERNAME
           name: nstuning-api-secrets
+    podLabels:
+      logformat: serilog
     image:
       pullPolicy: Always
     ingress:


### PR DESCRIPTION
Sets `podLabels: {logformat: serilog}` on the garge-api, garge-operator, nstuning-api (dev+prod) and bobby-api (prod) HelmReleases.

This is the final piece that activates the Serilog multiline-join + level parsing added in the Alloy pipeline: Alloy scopes that stage to `{logformat="serilog"}`, so pods must carry the label. Chart podLabels support (garge 0.1.45/0.1.29, nstuning-api 0.1.10, bobby-api 1.0.1) is already published and deployed.

Merging this will roll the pods and, once relabeled, multi-line EF Core SQL logs will collapse into a single Loki entry with a parsed level.