### PR TITLE
fix(ci): grant token write perms and harden workflow security

### DIFF
--- a/.github/workflows/check-version.yaml
+++ b/.github/workflows/check-version.yaml
@@ -21,10 +21,15 @@ on:
           - "production"
         default: "production"
 
+permissions: {}
+
 jobs:
   check-version:
     name: Check for new versions
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - name: checkout

--- a/.github/workflows/dependabot-title.yml
+++ b/.github/workflows/dependabot-title.yml
@@ -8,7 +8,7 @@ permissions: {}
 
 jobs:
   rewrite:
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     permissions:
       pull-requests: write
     uses: sondresjolyst/garge/.github/workflows/dependabot-title.yml@main


### PR DESCRIPTION
Fixes [run 30335019762](https://github.com/sondresjolyst/tumo-flux/actions/runs/30335019762): read-only `GITHUB_TOKEN` caused `git push` 403 → Create PR aborted.

- **check-version**: job perms (`contents`/`pull-requests: write`) + top-level `permissions: {}`. Clears alerts #3, #10.
- **dependabot-title**: gate on PR author, not spoofable `github.actor`. Clears #5.
