### PR TITLE
fix(ci): scan on master, not main

### DIFF
--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -2,9 +2,9 @@ name: Code scanning
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
-    branches: [main]
+    branches: [master]
   schedule:
     # Run every Wednesday at 00:00 UTC.
     - cron: 0 0 * * 3


### PR DESCRIPTION
Default branch is `master`, but `code-scanning.yml` triggered on `branches: [main]` → `push`/`pull_request` scans never fired; only the weekly `schedule` ran. That's why alerts #3/#5 didn't clear after #507 merged.

`main` → `master`. Restores push/PR scanning and rescans on merge, clearing the stale alerts.
