### PR TITLE
feat(traefik): add Traefik alongside ingress-nginx

### DIFF
--- a/clusters/production/kustomization.yaml
+++ b/clusters/production/kustomization.yaml
@@ -30,6 +30,7 @@ resources:
   - ../../components/third-party/redis
   - ../../components/third-party/spark-kubernetes-operator
   - ../../components/third-party/telegraf
+  - ../../components/third-party/traefik
   - ../../components/third-party/tumogroup
   - ./overlay/third-party/cert-manager
   - ./overlay/third-party/garge-app
@@ -39,6 +40,7 @@ resources:
   - ./overlay/third-party/influxdb
   - ./overlay/third-party/ingress-nginx
   - ./overlay/third-party/mosquitto
+  - ./overlay/third-party/traefik
 patches:
   - path: ./postBuild.yaml
   - path: ./overlay/third-party/bobby-api/helmRelease.yaml
@@ -67,4 +69,5 @@ patches:
   - path: ./overlay/third-party/alloy/helmRelease.yaml
   - path: ./overlay/third-party/redis/helmRelease.yaml
   - path: ./overlay/third-party/spark-kubernetes-operator/helmRelease.yaml
+  - path: ./overlay/third-party/traefik/helmRelease.yaml
   - path: ../../components/third-party/redis/ociRepo.yaml

--- a/clusters/production/overlay/third-party/cert-manager/certs/certificate.yaml
+++ b/clusters/production/overlay/third-party/cert-manager/certs/certificate.yaml
@@ -9,9 +9,9 @@ spec:
   secretTemplate:
     annotations:
       reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "monitor,bobby-prod,emqx"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "monitor,bobby-prod,emqx,traefik"
       reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "monitor,bobby-prod,emqx"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "monitor,bobby-prod,emqx,traefik"
   issuerRef:
     kind: ClusterIssuer
     name: ${CERT_ISSUER}

--- a/clusters/production/overlay/third-party/traefik/helmRelease.yaml
+++ b/clusters/production/overlay/third-party/traefik/helmRelease.yaml
@@ -1,0 +1,30 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: traefik
+  namespace: traefik
+spec:
+  chart:
+    spec:
+      version: ${TRAEFIK_VERSION} # Set in postBuild production
+  values:
+    deployment:
+      replicas: 2
+    ports:
+      web:
+        # Replaces ingress-nginx use-proxy-protocol + proxy-real-ip-cidr.
+        # 192.168.1.122 is the upstream HAProxy.
+        proxyProtocol:
+          trustedIPs:
+          - 192.168.1.122/32
+      websecure:
+        exposedPort: 444 # ingress-nginx service.ports.https
+        proxyProtocol:
+          trustedIPs:
+          - 192.168.1.122/32
+    resources:
+      limits:
+        memory: 1024Mi
+      requests:
+        cpu: 100m
+        memory: 1024Mi

--- a/clusters/production/overlay/third-party/traefik/kustomization.yaml
+++ b/clusters/production/overlay/third-party/traefik/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- nstuningRedirect.yaml

--- a/clusters/production/overlay/third-party/traefik/nstuningRedirect.yaml
+++ b/clusters/production/overlay/third-party/traefik/nstuningRedirect.yaml
@@ -1,0 +1,37 @@
+# Replacement for the nginx.ingress.kubernetes.io/server-snippet redirect in
+# ./overlay/third-party/nstuning-app/ingress.yaml. Snippet annotations have no
+# equivalent in Traefik's ingress-nginx provider, so this is expressed natively.
+# Only Traefik acts on these; the nginx Ingress keeps serving until cutover and
+# is deleted then.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: nstuning-redirect
+  namespace: nstuning-prod
+spec:
+  redirectRegex:
+    regex: "^https?://nstuning\\.no/(.*)"
+    replacement: "https://www.nstuning.no/${1}"
+    permanent: true
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: nstuning-redirect
+  namespace: nstuning-prod
+spec:
+  entryPoints:
+  - websecure
+  routes:
+  - kind: Rule
+    match: Host(`nstuning.no`)
+    middlewares:
+    - name: nstuning-redirect
+    services:
+    # Traefik's built-in no-op backend; the middleware answers before any backend
+    # is reached. Mirrors the "dummy-service" placeholder in the nginx Ingress.
+    - name: noop@internal
+      kind: TraefikService
+  tls:
+    # Reflected into nstuning-prod, covers nstuning.no and *.nstuning.no.
+    secretName: nstuning-wildcard-tls-cert

--- a/clusters/production/postBuild.yaml
+++ b/clusters/production/postBuild.yaml
@@ -38,6 +38,7 @@ spec:
       REDIS_VERSION: 27.0.18 # https://artifacthub.io/packages/helm/bitnami/redis
       SPARK_KUBERNETES_OPERATOR_VERSION: 1.8.0 # https://artifacthub.io/packages/helm/spark-kubernetes-operator/spark-kubernetes-operator
       TELEGRAF_VERSION: 1.8.73 # https://artifacthub.io/packages/helm/influxdata/telegraf
+      TRAEFIK_VERSION: 41.1.0 # https://artifacthub.io/packages/helm/traefik/traefik
     substituteFrom:
       - kind: ConfigMap
         name: tumo-flux-config

--- a/components/third-party/traefik/helmRelease.yaml
+++ b/components/third-party/traefik/helmRelease.yaml
@@ -1,0 +1,83 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: traefik
+  namespace: traefik
+spec:
+  chart:
+    spec:
+      chart: traefik
+      version: xx # Set by flux patch
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: flux-system
+  interval: 1m0s
+  install:
+    crds: Create
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+  values:
+    deployment:
+      podLabels:
+        app: traefik
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - traefik
+            topologyKey: kubernetes.io/hostname
+    ingressClass:
+      # ingress-nginx owns the default IngressClass while both controllers run.
+      # Two default classes is an error state - enable this at cutover.
+      enabled: false
+    providers:
+      kubernetesCRD:
+        enabled: true
+      kubernetesIngress:
+        # The ingress-nginx provider below claims every Ingress in this cluster.
+        # Leaving this on would make both providers handle the same objects.
+        enabled: false
+      kubernetesIngressNGINX:
+        # Reads ingressClassName: nginx and nginx.ingress.kubernetes.io/* annotations,
+        # so no Ingress resource needs to change. Requires Traefik v3.7+.
+        enabled: true
+        ingressClass: nginx
+        controllerClass: k8s.io/ingress-nginx
+        ingressClassByName: true # ingress-nginx controller.ingressClassByName
+        watchIngressWithoutClass: true # ingress-nginx controller.watchIngressWithoutClass
+        publishService:
+          # ingress-nginx keeps writing Ingress .status while both controllers run,
+          # otherwise they fight over status.loadBalancer.ingress[].
+          enabled: false
+        proxyBodySize: 104857600 # ingress-nginx proxy-body-size: 100m
+        proxyBufferSize: 16384 # ingress-nginx proxy-buffer-size: 16k
+    service:
+      spec:
+        externalTrafficPolicy: Local
+    tlsStore:
+      default:
+        # Replaces ingress-nginx extraArgs.default-ssl-certificate. The secret is
+        # mirrored into this namespace by reflector, see cert-manager certificate.yaml.
+        defaultCertificate:
+          secretName: tumo-wildcard-tls-cert
+    metrics:
+      prometheus:
+        service:
+          enabled: true
+        serviceMonitor:
+          enabled: true
+    resources:
+      limits:
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 512Mi

--- a/components/third-party/traefik/helmRepo.yaml
+++ b/components/third-party/traefik/helmRepo.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: traefik
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  url: https://traefik.github.io/charts

--- a/components/third-party/traefik/kustomization.yaml
+++ b/components/third-party/traefik/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml
+- helmRepo.yaml
+- helmRelease.yaml

--- a/components/third-party/traefik/namespace.yaml
+++ b/components/third-party/traefik/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: traefik
+  labels:
+    purpose: tumo-base-ns


### PR DESCRIPTION
Phase 1 of migrating off `ingress-nginx`, which is retired upstream.

Traefik is deployed **alongside** nginx on its own MetalLB IP. Both controllers serve the same Ingress resources; nginx keeps serving production traffic until cutover. Rollback is `git revert` — nginx never stops.

Follows https://doc.traefik.io/traefik/migrate/nginx-to-traefik/

## No Ingress resources change

Traefik's `kubernetesIngressNGINX` provider claims `ingressClassName: nginx` / `controllerClass: k8s.io/ingress-nginx` and translates the `nginx.ingress.kubernetes.io/*` annotations. All 13 Ingresses stay as-is.

## Chart defaults overridden

Two would conflict with the running nginx controller:

- `ingressClass` disabled — `isDefaultClass` defaults to `true`, and two default IngressClasses is an error state
- `providers.kubernetesIngress` disabled — would double-handle every Ingress alongside the nginx provider

`publishService.enabled: false` so nginx keeps owning `Ingress .status` (no race on `status.loadBalancer.ingress[]`).

## Settings carried over

| ingress-nginx | Traefik |
| --- | --- |
| `replicaCount: 2` | `deployment.replicas: 2` |
| `service.ports.https: 444` | `ports.websecure.exposedPort: 444` |
| `externalTrafficPolicy: Local` | `service.spec.externalTrafficPolicy: Local` |
| `use-proxy-protocol` + `proxy-real-ip-cidr: 192.168.1.122/32` | `ports.{web,websecure}.proxyProtocol.trustedIPs` |
| `extraArgs.default-ssl-certificate` | `tlsStore.default.defaultCertificate.secretName` |
| `proxy-body-size: 100m` | `proxyBodySize: 104857600` |
| `proxy-buffer-size: 16k` | `proxyBufferSize: 16384` |
| `ingressClassByName`, `watchIngressWithoutClass` | same keys on the provider |
| `metrics.serviceMonitor` | `metrics.prometheus.serviceMonitor` |

Dropped deliberately: `large-client-header-buffers: 4 32k` (Traefik's 1 MiB `maxHeaderBytes` default already exceeds it) and `worker-shutdown-timeout: 3600s` (no equivalent worth keeping; chart default `terminationGracePeriodSeconds: 60`).

## Redirects

`server-snippet` is the one annotation with no Traefik equivalent. The `nstuning.no` → `www.nstuning.no` redirect is reimplemented as a native `Middleware` (`redirectRegex`, path preserved) + `IngressRoute`, TLS from the existing reflected `nstuning-wildcard-tls-cert`. Only Traefik acts on it; the nginx Ingress is deleted at cutover.

`permanent-redirect` **is** supported, so `garge.no` needs no change.

## Verify before merging

- Confirm chart `41.1.0` ships Traefik >= v3.7 (required for this provider)
- `kubectl get ingress -A -o custom-columns=NS:.metadata.namespace,NAME:.metadata.name,CLASS:.spec.ingressClassName`

After Flux reconciles, curl each host against Traefik's LB IP while nginx still serves prod:

```sh
TRAEFIK_IP=$(kubectl -n traefik get svc traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
curl -sI --resolve "nstuning.no:443:$TRAEFIK_IP" https://nstuning.no/some/path | grep -i location
```
