### PR TITLE
feat(traefik): pin LB IP, add nstuning redirect, fix healthCheck

### DIFF
--- a/clusters/production/healthChecks.yaml
+++ b/clusters/production/healthChecks.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   timeout: 2m0s
   healthChecks:
-    - apiVersion: kustomize.toolkit.fluxcd.io/v1
-      kind: Kustomization
-      name: ingress-nginx
-      namespace: flux-system
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: traefik
+      namespace: traefik

--- a/clusters/production/kustomization.yaml
+++ b/clusters/production/kustomization.yaml
@@ -40,6 +40,7 @@ resources:
   - ./overlay/third-party/influxdb
   - ./overlay/third-party/ingress-nginx
   - ./overlay/third-party/mosquitto
+  - ./overlay/third-party/traefik
 patches:
   - path: ./postBuild.yaml
   - path: ./overlay/third-party/bobby-api/helmRelease.yaml

--- a/clusters/production/overlay/third-party/traefik/helmRelease.yaml
+++ b/clusters/production/overlay/third-party/traefik/helmRelease.yaml
@@ -10,6 +10,9 @@ spec:
   values:
     deployment:
       replicas: 2
+    service:
+      annotations:
+        metallb.universe.tf/loadBalancerIPs: 192.168.1.195
     ports:
       web:
         # Replaces ingress-nginx use-proxy-protocol + proxy-real-ip-cidr.

--- a/clusters/production/overlay/third-party/traefik/kustomization.yaml
+++ b/clusters/production/overlay/third-party/traefik/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- nstuningRedirect.yaml

--- a/clusters/production/overlay/third-party/traefik/nstuningRedirect.yaml
+++ b/clusters/production/overlay/third-party/traefik/nstuningRedirect.yaml
@@ -1,0 +1,29 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: nstuning-redirect
+  namespace: nstuning-prod
+spec:
+  redirectRegex:
+    regex: "^https?://nstuning\\.no/(.*)"
+    replacement: "https://www.nstuning.no/${1}"
+    permanent: true
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: nstuning-redirect
+  namespace: nstuning-prod
+spec:
+  entryPoints:
+  - websecure
+  routes:
+  - kind: Rule
+    match: Host(`nstuning.no`)
+    middlewares:
+    - name: nstuning-redirect
+    services:
+    - name: noop@internal
+      kind: TraefikService
+  tls:
+    secretName: nstuning-wildcard-tls-cert


### PR DESCRIPTION
Traefik CRDs exist now, so the `Middleware` and `IngressRoute` deferred in #513 can land. Also pins Traefik's LB IP and repoints the `flux-system` healthCheck at the Traefik HelmRelease.