### PR TITLE
fix(traefik): match nstuning redirect regardless of port

### DIFF
--- a/clusters/production/overlay/third-party/traefik/nstuningRedirect.yaml
+++ b/clusters/production/overlay/third-party/traefik/nstuningRedirect.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: nstuning-prod
 spec:
   redirectRegex:
-    regex: "^https?://nstuning\\.no/(.*)"
+    regex: "^https?://[^/]+/(.*)"
     replacement: "https://www.nstuning.no/${1}"
     permanent: true
 ---


### PR DESCRIPTION
The regex anchored on `nstuning.no/`, so a Host carrying a port missed the middleware and fell through to `noop@internal`, returning 418. The router already matches the host, so the middleware only needs the path.