### PR TITLE
fix(traefik): escape capture group from Flux substitution

### DIFF
--- a/clusters/production/overlay/third-party/traefik/nstuningRedirect.yaml
+++ b/clusters/production/overlay/third-party/traefik/nstuningRedirect.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   redirectRegex:
     regex: "^https?://[^/]+/(.*)"
-    replacement: "https://www.nstuning.no/${1}"
+    replacement: "https://www.nstuning.no/$${1}"
     permanent: true
 ---
 apiVersion: traefik.io/v1alpha1


### PR DESCRIPTION
Flux `postBuild.substitute` runs envsubst over the built manifests, so `${1}` was read as a variable name and expanded to empty, dropping the path from the redirect. `$$` escapes it.