### PR TITLE
chore(ingress-nginx): keep IngressClass on uninstall

### DIFF
--- a/clusters/production/overlay/third-party/ingress-nginx/helmRelease.yaml
+++ b/clusters/production/overlay/third-party/ingress-nginx/helmRelease.yaml
@@ -10,6 +10,9 @@ spec:
   values:
     controller:
       replicaCount: 2
+      ingressClassResource:
+        annotations:
+          helm.sh/resource-policy: keep
       service:
         ports:
           https: 444


### PR DESCRIPTION
All Ingresses still set `ingressClassName: nginx`, and the IngressClass belongs to the ingress-nginx release. `helm.sh/resource-policy: keep` leaves it behind when the release is removed at cutover.