### PR TITLE
fix(grafana): set ingressClassName to traefik

### DIFF
--- a/clusters/production/overlay/third-party/grafana/helmRelease.yaml
+++ b/clusters/production/overlay/third-party/grafana/helmRelease.yaml
@@ -8,6 +8,8 @@ spec:
     spec:
       version: ${GRAFANA_VERSION} # Set in postBuild production
   values:
+    ingress:
+      ingressClassName: traefik
     env:
       GF_DATABASE_HOST: postgresql-prod.tumogroup.com:5432
       GF_DATABASE_NAME: grafana


### PR DESCRIPTION
The ingress block lives in `grafana-helm-secret` and never set a class, so the API server defaulted it to `nginx` when the Ingress was created. That class no longer matches a controller.

Flux merges `valuesFrom` before `values`, so this can be set here rather than in the secret.
