### PR TITLE
fix(traefik): redirect to 443, not the exposed port

### DIFF
--- a/components/third-party/traefik/helmRelease.yaml
+++ b/components/third-party/traefik/helmRelease.yaml
@@ -45,10 +45,12 @@ spec:
         enabled: true
         publishedService:
           enabled: true
+    additionalArguments:
+    # websecure is exposed on 444 for HAProxy, but clients reach it on 443.
+    - --entrypoints.web.http.redirections.entrypoint.port=:443
     ports:
       web:
         http:
-          # Replaces the ssl-redirect the nginx provider applied per Ingress.
           redirections:
             entryPoint:
               to: websecure


### PR DESCRIPTION
The web entryPoint redirect took its port from `websecure`, sending clients to `https://host:444/`. HAProxy terminates on 443 and forwards to 444.
