### PR TITLE
fix(traefik): redirect target is a port, not an entryPoint

### DIFF
--- a/components/third-party/traefik/helmRelease.yaml
+++ b/components/third-party/traefik/helmRelease.yaml
@@ -45,15 +45,14 @@ spec:
         enabled: true
         publishedService:
           enabled: true
-    additionalArguments:
-    # websecure is exposed on 444 for HAProxy, but clients reach it on 443.
-    - --entrypoints.web.http.redirections.entrypoint.port=:443
     ports:
       web:
         http:
           redirections:
             entryPoint:
-              to: websecure
+              # Not websecure: the chart resolves that to its exposed port, 444.
+              # Clients reach HAProxy on 443.
+              to: ":443"
               scheme: https
               permanent: true
     service:


### PR DESCRIPTION
Traefik v3 has no `port` field on `redirections.entryPoint`, so the flag added in #521 crash-looped with `field not found, node: port`. The chart resolves `to: websecure` into its exposed port, 444; set the port directly instead.
