### PR TITLE
feat(traefik): enable the dashboard IngressRoute

### DIFF
--- a/components/third-party/traefik/helmRelease.yaml
+++ b/components/third-party/traefik/helmRelease.yaml
@@ -38,6 +38,9 @@ spec:
     ingressClass:
       enabled: true
       isDefaultClass: true
+    ingressRoute:
+      dashboard:
+        enabled: true
     providers:
       kubernetesCRD:
         enabled: true


### PR DESCRIPTION
Chart 41.x defaults it off, so `/dashboard/` 404s. It is served on the `traefik` entryPoint, which the Service does not expose, so it stays reachable only through port-forward.
