### PR TITLE
fix: patch telegraf chart version

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -48,4 +48,11 @@ jobs:
           flux build kustomization flux-system \
             --path ./clusters/production \
             --kustomization-file ./clusters/production/postBuild.yaml \
-            --dry-run > /dev/null
+            --dry-run > "${RUNNER_TEMP}/rendered.yaml"
+
+      - name: Check every chart version was patched
+        run: |
+          if grep -n "version: xx" "${RUNNER_TEMP}/rendered.yaml"; then
+            echo "::error::HelmRelease reached the cluster without a patched chart version"
+            exit 1
+          fi

--- a/clusters/production/kustomization.yaml
+++ b/clusters/production/kustomization.yaml
@@ -60,4 +60,5 @@ patches:
   - path: ./overlay/third-party/minecraft-hs/helmRelease.yaml
   - path: ./overlay/third-party/mosquitto/helmRelease.yaml
   - path: ./overlay/third-party/alloy/helmRelease.yaml
+  - path: ./overlay/third-party/telegraf/helmRelease.yaml
   - path: ./overlay/third-party/traefik/helmRelease.yaml


### PR DESCRIPTION
`clusters/production/overlay/third-party/telegraf/helmRelease.yaml` existed but was never listed under `patches:`, so telegraf shipped with the literal placeholder `version: xx` and helm-controller failed with `constraint parser error`.

Adds a CI step that greps the rendered output for `version: xx`. The build-only checks passed this through, so the guard is the actual fix for the class of bug.

Verified locally: telegraf now renders `version: 1.8.73`, and no `version: xx` remains anywhere in the render.