### PR TITLE
fix: pull influxdb chart from bitnami OCI

### DIFF
--- a/components/third-party/influxdb/helmRepo.yaml
+++ b/components/third-party/influxdb/helmRepo.yaml
@@ -5,4 +5,5 @@ metadata:
   namespace: flux-system
 spec:
   interval: 10m
-  url: https://charts.bitnami.com/bitnami
+  type: oci
+  url: oci://registry-1.docker.io/bitnamicharts


### PR DESCRIPTION
`HelmChart 'flux-system/monitor-influxdb' is not ready: chart pull error: ... Get "oci://registry-1.docker.io/bitnamicharts/influxdb:7.1.20": unsupported protocol scheme "oci"`

The index at `https://charts.bitnami.com/bitnami` still resolves, but the chart entries now point at `oci://` download URLs that source-controller cannot fetch over HTTP. Switches the HelmRepository to `type: oci` against the registry directly; `INFLUXDB_VERSION` and the HelmRelease are unchanged.

This will trigger a Helm upgrade of influxdb, which is stateful (nfs PVC). Worth watching the pod after merge.