### PR TITLE
fix: move influxdb values to chart 7 layout

### DIFF
--- a/clusters/production/overlay/third-party/influxdb/helmRelease.yaml
+++ b/clusters/production/overlay/third-party/influxdb/helmRelease.yaml
@@ -13,10 +13,9 @@ spec:
       enabled: true
       storageClass: nfs
       size: 8Gi
-    influxdb:
-      service:
-        type: LoadBalancer
-      resources:
-        requests:
-          cpu: "100m"
-          memory: "512Mi"
+    service:
+      type: LoadBalancer
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "512Mi"

--- a/components/third-party/influxdb/helmRelease.yaml
+++ b/components/third-party/influxdb/helmRelease.yaml
@@ -23,5 +23,3 @@ spec:
       requests:
         cpu: "100m"
         memory: "512Mi"
-    auth:
-      existingSecret: influxdb-secret

--- a/components/third-party/influxdb/helmRelease.yaml
+++ b/components/third-party/influxdb/helmRelease.yaml
@@ -18,10 +18,10 @@ spec:
     remediation:
       retries: 3
   values:
-    influxdb:
-      resources:
-        requests:
-          cpu: "100m"
-          memory: "512Mi"
+    objectStore: file
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "512Mi"
     auth:
       existingSecret: influxdb-secret


### PR DESCRIPTION
Chart 7 restructured its values and removed the `influxdb:` key. As a result `influxdb.service.type` and `influxdb.resources` were no longer read by the chart, so the LoadBalancer service type and the resource requests had no effect.

- `influxdb.service.type` becomes `service.type`
- `influxdb.resources` becomes `resources`
- adds `objectStore: file`
- removes `auth.existingSecret`

`objectStore` defaults to `memory`, and the chart ignores `persistence` unless the object store is file-backed. Without this the release starts with no persistent volume.

Chart 7 supports `auth.existingSecret` only when the data store is already populated. The store is empty, so the admin token is created by the chart instead of supplied through `influxdb-secret`.
