### PR TITLE
fix: pull influxdb image from bitnamilegacy

### DIFF
--- a/components/third-party/influxdb/helmRelease.yaml
+++ b/components/third-party/influxdb/helmRelease.yaml
@@ -18,6 +18,8 @@ spec:
     remediation:
       retries: 3
   values:
+    image:
+      repository: bitnamilegacy/influxdb
     objectStore: file
     resources:
       requests:


### PR DESCRIPTION
The chart default `docker.io/bitnami/influxdb:3.4.1-debian-12-r0` does not exist and the pod fails with `ErrImagePull`. The `bitnami/influxdb` repository carries no 3.4.x tags; the image is published as `bitnamilegacy/influxdb:3.4.1-debian-12-r0`.
