### PR TITLE
fix: pull influxdb hook job image from bitnamilegacy

### DIFF
--- a/components/third-party/influxdb/helmRelease.yaml
+++ b/components/third-party/influxdb/helmRelease.yaml
@@ -20,6 +20,9 @@ spec:
   values:
     image:
       repository: bitnamilegacy/influxdb
+    createAdminTokenJob:
+      image:
+        repository: bitnamilegacy/kubectl
     objectStore: file
     resources:
       requests:


### PR DESCRIPTION
The admin token hook Jobs pull `docker.io/bitnami/kubectl:1.33.4-debian-12-r0`, which does not exist and fails with `ErrImagePull`. The image is published as `bitnamilegacy/kubectl:1.33.4-debian-12-r0`.

Both the create and the delete job read `createAdminTokenJob.image`. The delete job runs as an uninstall hook, so this also blocks `helm uninstall` from completing.
