### PR TITLE
feat: add altinnendata to production cluster

### DIFF
--- a/clusters/production/kustomization.yaml
+++ b/clusters/production/kustomization.yaml
@@ -15,6 +15,9 @@ resources:
   - ../../components/third-party/nstuning
   - ../../components/third-party/nstuning-api
   - ../../components/third-party/nstuning-app
+  - ../../components/third-party/altinnendata
+  - ../../components/third-party/altinnendata-api
+  - ../../components/third-party/altinnendata-app
   - ../../components/third-party/home-assistant
   - ../../components/third-party/kube-prometheus-stack
   - ../../components/third-party/reflector
@@ -44,6 +47,8 @@ patches:
   - path: ./overlay/third-party/garge-operator/helmRelease.yaml
   - path: ./overlay/third-party/nstuning-api/helmRelease.yaml
   - path: ./overlay/third-party/nstuning-app/helmRelease.yaml
+  - path: ./overlay/third-party/altinnendata-api/helmRelease.yaml
+  - path: ./overlay/third-party/altinnendata-app/helmRelease.yaml
   - path: ./overlay/third-party/grafana/helmRelease.yaml
   - path: ./overlay/third-party/home-assistant-et/helmRelease.yaml
   - path: ./overlay/third-party/home-assistant/helmRelease.yaml

--- a/clusters/production/overlay/third-party/altinnendata-api/helmRelease.yaml
+++ b/clusters/production/overlay/third-party/altinnendata-api/helmRelease.yaml
@@ -1,0 +1,140 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: altinnendata-api
+  namespace: altinnendata-dev
+spec:
+  chart:
+    spec:
+      chart: altinnendata-api
+      version: ${ALTINNENDATA_API_VERSION} # Set in postBuild production
+  values:
+    env:
+      - name: CONNECTIONSTRINGS__DEFAULTCONNECTION
+        secretKeyRef:
+          key: CONNECTIONSTRINGS__DEFAULTCONNECTION
+          name: altinnendata-api-secrets
+      - name: JWT__KEY
+        secretKeyRef:
+          key: JWT__KEY
+          name: altinnendata-api-secrets
+      - name: JWT__ISSUER
+        secretKeyRef:
+          key: JWT__ISSUER
+          name: altinnendata-api-secrets
+      - name: BREVOSETTINGS__APIKEY
+        secretKeyRef:
+          key: BREVOSETTINGS__APIKEY
+          name: altinnendata-api-secrets
+      - name: BREVOSETTINGS__SENDEREMAIL
+        secretKeyRef:
+          key: BREVOSETTINGS__SENDEREMAIL
+          name: altinnendata-api-secrets
+      - name: BREVOSETTINGS__SENDERNAME
+        secretKeyRef:
+          key: BREVOSETTINGS__SENDERNAME
+          name: altinnendata-api-secrets
+      - name: SEED__ADMINEMAIL
+        secretKeyRef:
+          key: SEED__ADMINEMAIL
+          name: altinnendata-api-secrets
+      - name: SEED__ADMINPASSWORD
+        secretKeyRef:
+          key: SEED__ADMINPASSWORD
+          name: altinnendata-api-secrets
+    podLabels:
+      logformat: serilog
+    image:
+      tag: "dev"
+      pullPolicy: Always
+    ingress:
+      enabled: true
+      className: traefik
+      annotations:
+        cert-manager.io/cluster-issuer: "letsencrypt-prod"
+      hosts:
+        - host: altinnendata-api-dev.prod.tumogroup.com
+          paths:
+            - path: /
+              pathType: Prefix
+      tls:
+        - secretName: altinnendata-api-tls
+          hosts:
+            - altinnendata-api-dev.prod.tumogroup.com
+    resources:
+      requests:
+        memory: "512Mi"
+        cpu: "500m"
+      limits:
+        memory: "512Mi"
+        cpu: "500m"
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: altinnendata-api
+  namespace: altinnendata-prod
+spec:
+  chart:
+    spec:
+      chart: altinnendata-api
+      version: ${ALTINNENDATA_API_VERSION} # Set in postBuild production
+  values:
+    env:
+      - name: CONNECTIONSTRINGS__DEFAULTCONNECTION
+        secretKeyRef:
+          key: CONNECTIONSTRINGS__DEFAULTCONNECTION
+          name: altinnendata-api-secrets
+      - name: JWT__KEY
+        secretKeyRef:
+          key: JWT__KEY
+          name: altinnendata-api-secrets
+      - name: JWT__ISSUER
+        secretKeyRef:
+          key: JWT__ISSUER
+          name: altinnendata-api-secrets
+      - name: BREVOSETTINGS__APIKEY
+        secretKeyRef:
+          key: BREVOSETTINGS__APIKEY
+          name: altinnendata-api-secrets
+      - name: BREVOSETTINGS__SENDEREMAIL
+        secretKeyRef:
+          key: BREVOSETTINGS__SENDEREMAIL
+          name: altinnendata-api-secrets
+      - name: BREVOSETTINGS__SENDERNAME
+        secretKeyRef:
+          key: BREVOSETTINGS__SENDERNAME
+          name: altinnendata-api-secrets
+      - name: SEED__ADMINEMAIL
+        secretKeyRef:
+          key: SEED__ADMINEMAIL
+          name: altinnendata-api-secrets
+      - name: SEED__ADMINPASSWORD
+        secretKeyRef:
+          key: SEED__ADMINPASSWORD
+          name: altinnendata-api-secrets
+    podLabels:
+      logformat: serilog
+    image:
+      pullPolicy: Always
+    ingress:
+      enabled: true
+      className: traefik
+      annotations:
+        cert-manager.io/cluster-issuer: "letsencrypt-prod"
+      hosts:
+        - host: altinnendata-api.prod.tumogroup.com
+          paths:
+            - path: /
+              pathType: Prefix
+      tls:
+        - secretName: altinnendata-api-tls
+          hosts:
+            - altinnendata-api.prod.tumogroup.com
+    resources:
+      requests:
+        memory: "512Mi"
+        cpu: "500m"
+      limits:
+        memory: "512Mi"
+        cpu: "500m"

--- a/clusters/production/overlay/third-party/altinnendata-app/helmRelease.yaml
+++ b/clusters/production/overlay/third-party/altinnendata-app/helmRelease.yaml
@@ -1,0 +1,96 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: altinnendata-app
+  namespace: altinnendata-dev
+spec:
+  chart:
+    spec:
+      chart: altinnendata-app
+      version: ${ALTINNENDATA_APP_VERSION} # Set in postBuild production
+  values:
+    env:
+      - name: NEXTAUTH_SECRET
+        secretKeyRef:
+          key: NEXTAUTH_SECRET
+          name: altinnendata-app-secrets
+      - name: NEXTAUTH_URL
+        secretKeyRef:
+          key: NEXTAUTH_URL
+          name: altinnendata-app-secrets
+      - name: ALTINNENDATA_API_JWT_SECRET
+        secretKeyRef:
+          key: ALTINNENDATA_API_JWT_SECRET
+          name: altinnendata-app-secrets
+    image:
+      tag: "dev"
+      pullPolicy: Always
+    ingress:
+      enabled: true
+      className: traefik
+      annotations:
+        cert-manager.io/cluster-issuer: "letsencrypt-prod"
+      hosts:
+        - host: dev.altinnendata.no
+          paths:
+            - path: /
+              pathType: Prefix
+      tls:
+        - secretName: altinnendata-app-tls
+          hosts:
+            - dev.altinnendata.no
+    resources:
+      requests:
+        memory: "512Mi"
+        cpu: "500m"
+      limits:
+        memory: "512Mi"
+        cpu: "500m"
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: altinnendata-app
+  namespace: altinnendata-prod
+spec:
+  chart:
+    spec:
+      chart: altinnendata-app
+      version: ${ALTINNENDATA_APP_VERSION} # Set in postBuild production
+  values:
+    env:
+      - name: NEXTAUTH_SECRET
+        secretKeyRef:
+          key: NEXTAUTH_SECRET
+          name: altinnendata-app-secrets
+      - name: NEXTAUTH_URL
+        secretKeyRef:
+          key: NEXTAUTH_URL
+          name: altinnendata-app-secrets
+      - name: ALTINNENDATA_API_JWT_SECRET
+        secretKeyRef:
+          key: ALTINNENDATA_API_JWT_SECRET
+          name: altinnendata-app-secrets
+    image:
+      pullPolicy: Always
+    ingress:
+      enabled: true
+      className: traefik
+      annotations:
+        cert-manager.io/cluster-issuer: "letsencrypt-prod"
+      hosts:
+        - host: www.altinnendata.no
+          paths:
+            - path: /
+              pathType: Prefix
+      tls:
+        - secretName: altinnendata-app-tls
+          hosts:
+            - www.altinnendata.no
+    resources:
+      requests:
+        memory: "512Mi"
+        cpu: "500m"
+      limits:
+        memory: "512Mi"
+        cpu: "500m"

--- a/clusters/production/overlay/third-party/cert-manager/certs/certificate.yaml
+++ b/clusters/production/overlay/third-party/cert-manager/certs/certificate.yaml
@@ -89,3 +89,26 @@ spec:
   dnsNames:
   - "nstuning.no"
   - "*.nstuning.no"
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: altinnendata-wildcard-tls
+  namespace: default
+spec:
+  secretName: altinnendata-wildcard-tls-cert
+  secretTemplate:
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "altinnendata-dev,altinnendata-prod"
+      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "altinnendata-dev,altinnendata-prod"
+  issuerRef:
+    kind: ClusterIssuer
+    name: ${CERT_ISSUER}
+  duration: 2160h # 90d
+  renewBefore: 762h # 32d. Let's Encrypt will email an alert if 30d remain and cert has not been renewed.
+  commonName: "altinnendata.no"
+  dnsNames:
+  - "altinnendata.no"
+  - "*.altinnendata.no"

--- a/clusters/production/overlay/third-party/traefik/altinnendataRedirect.yaml
+++ b/clusters/production/overlay/third-party/traefik/altinnendataRedirect.yaml
@@ -1,0 +1,29 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: altinnendata-redirect
+  namespace: altinnendata-prod
+spec:
+  redirectRegex:
+    regex: "^https?://[^/]+/(.*)"
+    replacement: "https://www.altinnendata.no/$${1}"
+    permanent: true
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: altinnendata-redirect
+  namespace: altinnendata-prod
+spec:
+  entryPoints:
+  - websecure
+  routes:
+  - kind: Rule
+    match: Host(`altinnendata.no`)
+    middlewares:
+    - name: altinnendata-redirect
+    services:
+    - name: noop@internal
+      kind: TraefikService
+  tls:
+    secretName: altinnendata-wildcard-tls-cert

--- a/clusters/production/postBuild.yaml
+++ b/clusters/production/postBuild.yaml
@@ -20,6 +20,8 @@ spec:
       GARGE_OPERATOR_VERSION: 0.1.31 # https://artifacthub.io/packages/helm/garge/garge-operator
       NSTUNING_API_VERSION: 0.1.13 # https://artifacthub.io/packages/helm/tumogroup/nstuning-api
       NSTUNING_APP_VERSION: 0.1.12 # https://artifacthub.io/packages/helm/tumogroup/nstuning-app
+      ALTINNENDATA_API_VERSION: 0.1.0 # https://artifacthub.io/packages/helm/tumogroup/altinnendata-api
+      ALTINNENDATA_APP_VERSION: 0.1.0 # https://artifacthub.io/packages/helm/tumogroup/altinnendata-app
       GRAFANA_VERSION: 12.10.4 # https://artifacthub.io/packages/helm/grafana-community/grafana
       HOME_ASSISTANT_VERSION_ET: 2.8.1 # https://artifacthub.io/packages/helm/alekc/home-assistant
       HOME_ASSISTANT_VERSION: 2.8.1 # https://artifacthub.io/packages/helm/alekc/home-assistant

--- a/components/third-party/altinnendata-api/helmRelease.yaml
+++ b/components/third-party/altinnendata-api/helmRelease.yaml
@@ -1,0 +1,55 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: altinnendata-api
+  namespace: altinnendata-dev
+spec:
+  releaseName: altinnendata-api
+  chart:
+    spec:
+      chart: altinnendata-api
+      version: xx # Set by flux patch
+      sourceRef:
+        kind: HelmRepository
+        name: tumogroup
+        namespace: flux-system
+  interval: 5m
+  install:
+    remediation:
+      retries: 3
+  values:
+    resources:
+      requests:
+        memory: "512Mi"
+        cpu: "500m"
+      limits:
+        memory: "512Mi"
+        cpu: "500m"
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: altinnendata-api
+  namespace: altinnendata-prod
+spec:
+  releaseName: altinnendata-api
+  chart:
+    spec:
+      chart: altinnendata-api
+      version: xx # Set by flux patch
+      sourceRef:
+        kind: HelmRepository
+        name: tumogroup
+        namespace: flux-system
+  interval: 5m
+  install:
+    remediation:
+      retries: 3
+  values:
+    resources:
+      requests:
+        memory: "512Mi"
+        cpu: "500m"
+      limits:
+        memory: "512Mi"
+        cpu: "500m"

--- a/components/third-party/altinnendata-api/kustomization.yaml
+++ b/components/third-party/altinnendata-api/kustomization.yaml
@@ -1,6 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- gargeRedirect.yaml
-- nstuningRedirect.yaml
-- altinnendataRedirect.yaml
+- helmRelease.yaml

--- a/components/third-party/altinnendata-app/helmRelease.yaml
+++ b/components/third-party/altinnendata-app/helmRelease.yaml
@@ -1,0 +1,55 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: altinnendata-app
+  namespace: altinnendata-dev
+spec:
+  releaseName: altinnendata-app
+  chart:
+    spec:
+      chart: altinnendata-app
+      version: xx # Set by flux patch
+      sourceRef:
+        kind: HelmRepository
+        name: tumogroup
+        namespace: flux-system
+  interval: 5m
+  install:
+    remediation:
+      retries: 3
+  values:
+    resources:
+      requests:
+        memory: "512Mi"
+        cpu: "500m"
+      limits:
+        memory: "512Mi"
+        cpu: "500m"
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: altinnendata-app
+  namespace: altinnendata-prod
+spec:
+  releaseName: altinnendata-app
+  chart:
+    spec:
+      chart: altinnendata-app
+      version: xx # Set by flux patch
+      sourceRef:
+        kind: HelmRepository
+        name: tumogroup
+        namespace: flux-system
+  interval: 5m
+  install:
+    remediation:
+      retries: 3
+  values:
+    resources:
+      requests:
+        memory: "512Mi"
+        cpu: "500m"
+      limits:
+        memory: "512Mi"
+        cpu: "500m"

--- a/components/third-party/altinnendata-app/kustomization.yaml
+++ b/components/third-party/altinnendata-app/kustomization.yaml
@@ -1,6 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- gargeRedirect.yaml
-- nstuningRedirect.yaml
-- altinnendataRedirect.yaml
+- helmRelease.yaml

--- a/components/third-party/altinnendata/kustomization.yaml
+++ b/components/third-party/altinnendata/kustomization.yaml
@@ -1,6 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- gargeRedirect.yaml
-- nstuningRedirect.yaml
-- altinnendataRedirect.yaml
+- namespace.yaml

--- a/components/third-party/altinnendata/namespace.yaml
+++ b/components/third-party/altinnendata/namespace.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: altinnendata-dev
+  labels:
+    altinnendata-wildcard-sync: altinnendata-wildcard-tls-cert
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: altinnendata-prod
+  labels:
+    altinnendata-wildcard-sync: altinnendata-wildcard-tls-cert


### PR DESCRIPTION
Namespaces, helm releases for api and app, wildcard certificate for altinnendata.no and the apex redirect.

Blocked until:
- the charts PR is merged and the charts are published
- `ALTINNENDATA_API_VERSION`/`ALTINNENDATA_APP_VERSION` in postBuild match the published chart versions
- DNS for altinnendata.no points at the cluster, otherwise the certificate stays pending