### PR TITLE
feat: pass SITE__BASEURL to altinnendata-api

### DIFF
--- a/clusters/production/overlay/third-party/altinnendata-api/helmRelease.yaml
+++ b/clusters/production/overlay/third-party/altinnendata-api/helmRelease.yaml
@@ -42,6 +42,11 @@ spec:
         secretKeyRef:
           key: SEED__ADMINPASSWORD
           name: altinnendata-api-secrets
+      # Password and invite emails link back here, so it must match this environment.
+      - name: SITE__BASEURL
+        secretKeyRef:
+          key: SITE__BASEURL
+          name: altinnendata-api-secrets
     podLabels:
       logformat: serilog
     image:
@@ -112,6 +117,11 @@ spec:
       - name: SEED__ADMINPASSWORD
         secretKeyRef:
           key: SEED__ADMINPASSWORD
+          name: altinnendata-api-secrets
+      # Password and invite emails link back here, so it must match this environment.
+      - name: SITE__BASEURL
+        secretKeyRef:
+          key: SITE__BASEURL
           name: altinnendata-api-secrets
     podLabels:
       logformat: serilog


### PR DESCRIPTION
Both `altinnendata-api` releases now read `SITE__BASEURL` from `altinnendata-api-secrets`, the key added in tumo-platform.

The API uses it for links in invite and password-reset emails. `altinnendata-dev` gets the dev host, `altinnendata-prod` the production host, from each zone's secrets file.

Merge after tumo-platform, so the key exists before the pods restart.